### PR TITLE
Get WS provider working

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-	"extends": ["next/core-web-vitals"]
+	"extends": "next/core-web-vitals",
+	"rules": {
+		"@next/next/no-img-element": "off"
+	}
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,19 @@
-# Use the official Node.js image as the base image
-FROM node:20.5.1
-
-# Set the working directory in the container
+# Build stage
+FROM node:20.5.1 AS build
 WORKDIR /app
-
-# Copy package.json and package-lock.json (or yarn.lock) to the working directory
 COPY package*.json ./
-
-# Install dependencies
 RUN npm install
-
-# Copy the source code into the container
 COPY . .
-
-# Build the Next.js application
 RUN npm run build
 
-# Expose port 3000 (or any other port your app might run on)
+# Production stage
+FROM node:20.5.1-alpine
+WORKDIR /app
+COPY package*.json ./
+# Only install production dependencies
+RUN npm install --only=production
+# Copy built app from the previous stage
+COPY --from=build /app/.next ./.next
+COPY --from=build /app/public ./public
 EXPOSE 3000
-
-# Command to run the application
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use the official Node.js image as the base image
+FROM node:20.5.1
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy package.json and package-lock.json (or yarn.lock) to the working directory
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the source code into the container
+COPY . .
+
+# Build the Next.js application
+RUN npm run build
+
+# Expose port 3000 (or any other port your app might run on)
+EXPOSE 3000
+
+# Command to run the application
+CMD ["npm", "start"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,22 +140,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.20.tgz",
-			"integrity": "sha512-Y6jd1ahLubuYweD/zJH+vvOY141v4f9igNQAQ+MBgq9JlHS2iTsZKn1aMsb3vGccZsXI16VzTBw52Xx0DWmtnA==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.0.tgz",
+			"integrity": "sha512-97z/ju/Jy1rZmDxybphrBuI+jtJjFVoz7Mr9yUQVVVi+DNZE333uFQeMOqcCIy1x3WYBIbWftUSLmbNXNT7qFQ==",
 			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.22.13",
-				"@babel/generator": "^7.22.15",
+				"@babel/generator": "^7.23.0",
 				"@babel/helper-compilation-targets": "^7.22.15",
-				"@babel/helper-module-transforms": "^7.22.20",
-				"@babel/helpers": "^7.22.15",
-				"@babel/parser": "^7.22.16",
+				"@babel/helper-module-transforms": "^7.23.0",
+				"@babel/helpers": "^7.23.0",
+				"@babel/parser": "^7.23.0",
 				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.22.20",
-				"@babel/types": "^7.22.19",
-				"convert-source-map": "^1.7.0",
+				"@babel/traverse": "^7.23.0",
+				"@babel/types": "^7.23.0",
+				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
 				"json5": "^2.2.3",
@@ -179,11 +179,11 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.15.tgz",
-			"integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+			"integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
 			"dependencies": {
-				"@babel/types": "^7.22.15",
+				"@babel/types": "^7.23.0",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -252,12 +252,12 @@
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-			"integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
 			"dependencies": {
-				"@babel/template": "^7.22.5",
-				"@babel/types": "^7.22.5"
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -286,9 +286,9 @@
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.20.tgz",
-			"integrity": "sha512-dLT7JVWIUUxKOs1UnJUBR3S70YK+pKX6AbJgB2vMIvEkZkrfJDbYDJesnPshtKV4LhDOR3Oc5YULeDizRek+5A==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
+			"integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
 			"peer": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.20",
@@ -361,14 +361,14 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.15.tgz",
-			"integrity": "sha512-7pAjK0aSdxOwR+CcYAqgWOGy5dcfvzsTIfFTb2odQqW47MDfv14UaJDY6eng8ylM2EaeKXdxaSWESbkmaQHTmw==",
+			"version": "7.23.1",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.1.tgz",
+			"integrity": "sha512-chNpneuK18yW5Oxsr+t553UZzzAs3aZnFm4bxhebsNTeshrC95yA7l5yl7GBAG+JG1rF0F7zzD2EixK9mWSDoA==",
 			"peer": true,
 			"dependencies": {
 				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.22.15",
-				"@babel/types": "^7.22.15"
+				"@babel/traverse": "^7.23.0",
+				"@babel/types": "^7.23.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -452,9 +452,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.22.16",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
-			"integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+			"integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -477,9 +477,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
-			"integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
+			"version": "7.23.1",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.1.tgz",
+			"integrity": "sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==",
 			"dev": true,
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
@@ -502,18 +502,18 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.20.tgz",
-			"integrity": "sha512-eU260mPZbU7mZ0N+X10pxXhQFMGTeLb9eFS0mxehS8HZp9o1uSnFeWQuG1UPrlxgA7QoUzFhOnilHDp0AXCyHw==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.0.tgz",
+			"integrity": "sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==",
 			"dependencies": {
 				"@babel/code-frame": "^7.22.13",
-				"@babel/generator": "^7.22.15",
+				"@babel/generator": "^7.23.0",
 				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-function-name": "^7.22.5",
+				"@babel/helper-function-name": "^7.23.0",
 				"@babel/helper-hoist-variables": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.22.16",
-				"@babel/types": "^7.22.19",
+				"@babel/parser": "^7.23.0",
+				"@babel/types": "^7.23.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -530,12 +530,12 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.22.19",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.19.tgz",
-			"integrity": "sha512-P7LAw/LbojPzkgp5oznjE6tQEIWbp4PkkfrZDINTro9zgBRtI324/EYsiSI7lhPbpIQ+DCeR2NNmMWANGGfZsg==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+			"integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.22.5",
-				"@babel/helper-validator-identifier": "^7.22.19",
+				"@babel/helper-validator-identifier": "^7.22.20",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
@@ -581,9 +581,9 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.8.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.1.tgz",
-			"integrity": "sha512-PWiOzLIUAjN/w5K17PoF4n6sKBw0gqLHPhywmYHP4t1VFQQVYeb1yWsJwnMVEMl3tUHME7X/SJPZLmtG7XBDxQ==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.0.tgz",
+			"integrity": "sha512-zJmuCWj2VLBt4c25CfBIbMZLGLyhkvs7LznyVX5HfpzeocThgIj5XQK4L+g3U36mMcx8bPMhGyPpwCATamC4jQ==",
 			"dev": true,
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1010,9 +1010,9 @@
 			}
 		},
 		"node_modules/@ethersproject/providers": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.1.tgz",
-			"integrity": "sha512-vZveG/DLyo+wk4Ga1yx6jSEHrLPgmTt+dFv0dv8URpVCRf0jVhalps1jq/emN/oXnMRsC7cQgAF32DcXLL7BPQ==",
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+			"integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
 			"funding": [
 				{
 					"type": "individual",
@@ -2085,9 +2085,9 @@
 			"integrity": "sha512-TKuAfDwsFHMFkHtxOQcHkD3sH6LwS/xOdJ3yD/T64V65bOWUfo2gs/yylPFKtb+VQdeto0Q33NJ0hyreFes2tQ=="
 		},
 		"node_modules/@rushstack/eslint-patch": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.4.0.tgz",
-			"integrity": "sha512-cEjvTPU32OM9lUFegJagO0mRnIn+rbqrG89vV8/xLnLFX0DoR0r1oy5IlTga71Q7uT3Qus7qm7wgeiMT/+Irlg==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.5.0.tgz",
+			"integrity": "sha512-EF3948ckf3f5uPgYbQ6GhyA56Dmv8yg0+ir+BroRjwdxyZJsekhZzawOecC2rOTPCz173t7ZcR1HHZu0dZgOCw==",
 			"dev": true
 		},
 		"node_modules/@styled-system/background": {
@@ -2217,9 +2217,9 @@
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.44.2",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
-			"integrity": "sha512-sdPRb9K6iL5XZOmBubg8yiFp5yS/JdUDQsq5e6h95km91MCYMuvp7mh1fjPEYUhvHepKpZOjnEaMBR4PxjWDzg==",
+			"version": "8.44.3",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.3.tgz",
+			"integrity": "sha512-iM/WfkwAhwmPff3wZuPLYiHX18HI24jU8k1ZSH7P8FHwxTjZ2P6CoX2wnF43oprR+YXJM6UUxATkNvyv/JHd+g==",
 			"peer": true,
 			"dependencies": {
 				"@types/estree": "*",
@@ -2227,9 +2227,9 @@
 			}
 		},
 		"node_modules/@types/eslint-scope": {
-			"version": "3.7.4",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
-			"integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+			"version": "3.7.5",
+			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.5.tgz",
+			"integrity": "sha512-JNvhIEyxVW6EoMIFIvj93ZOywYFatlpu9deeH6eSx6PE3WHYvHaQtmHmQeNw7aA81bYGBPPQqdtBm6b1SsQMmA==",
 			"peer": true,
 			"dependencies": {
 				"@types/eslint": "*",
@@ -2237,14 +2237,14 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-			"integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.2.tgz",
+			"integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA=="
 		},
 		"node_modules/@types/estree-jsx": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.0.tgz",
-			"integrity": "sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.1.tgz",
+			"integrity": "sha512-sHyakZlAezNFxmYRo0fopDZW+XvK6ipeZkkp5EAOLjdPfZp8VjZBJ67vSRI99RSCAoqXVmXOHS4fnWoxpuGQtQ==",
 			"dependencies": {
 				"@types/estree": "*"
 			}
@@ -2284,22 +2284,22 @@
 			"dev": true
 		},
 		"node_modules/@types/mdast": {
-			"version": "3.0.12",
-			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.12.tgz",
-			"integrity": "sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==",
+			"version": "3.0.13",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.13.tgz",
+			"integrity": "sha512-HjiGiWedR0DVFkeNljpa6Lv4/IZU1+30VY5d747K7lBudFc3R0Ibr6yJ9lN3BE28VnZyDfLF/VB1Ql1ZIbKrmg==",
 			"dependencies": {
 				"@types/unist": "^2"
 			}
 		},
 		"node_modules/@types/mdx": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.7.tgz",
-			"integrity": "sha512-BG4tyr+4amr3WsSEmHn/fXPqaCba/AYZ7dsaQTiavihQunHSIxk+uAtqsjvicNpyHN6cm+B9RVrUOtW9VzIKHw=="
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.8.tgz",
+			"integrity": "sha512-r7/zWe+f9x+zjXqGxf821qz++ld8tp6Z4jUS6qmPZUXH6tfh4riXOhAqb12tWGWAevCFtMt1goLWkQMqIJKpsA=="
 		},
 		"node_modules/@types/ms": {
-			"version": "0.7.31",
-			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
+			"version": "0.7.32",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.32.tgz",
+			"integrity": "sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g=="
 		},
 		"node_modules/@types/node": {
 			"version": "20.4.10",
@@ -2307,9 +2307,9 @@
 			"integrity": "sha512-vwzFiiy8Rn6E0MtA13/Cxxgpan/N6UeNYR9oUu6kuJWxu6zCk98trcDp8CBhbtaeuq9SykCmXkFr2lWLoPcvLg=="
 		},
 		"node_modules/@types/prop-types": {
-			"version": "15.7.6",
-			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.6.tgz",
-			"integrity": "sha512-RK/kBbYOQQHLYj9Z95eh7S6t7gq4Ojt/NT8HTk8bWVhA5DaF+5SMnxHKkP4gPNN3wAZkKP+VjAf0ebtYzf+fxg=="
+			"version": "15.7.7",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.7.tgz",
+			"integrity": "sha512-FbtmBWCcSa2J4zL781Zf1p5YUBXQomPEcep9QZCfRfQgTxz3pJWiDFLebohZ9fFntX5ibzOkSsrJ0TEew8cAog=="
 		},
 		"node_modules/@types/react": {
 			"version": "18.2.20",
@@ -2331,14 +2331,14 @@
 			}
 		},
 		"node_modules/@types/scheduler": {
-			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-			"integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
+			"version": "0.16.4",
+			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.4.tgz",
+			"integrity": "sha512-2L9ifAGl7wmXwP4v3pN4p2FLhD0O1qsJpvKmNin5VA8+UvNVb447UDaAEV6UdrkA+m/Xs58U1RFps44x6TFsVQ=="
 		},
 		"node_modules/@types/styled-components": {
-			"version": "5.1.27",
-			"resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.27.tgz",
-			"integrity": "sha512-oY9c1SdztRRF0QDQdwXEenfAjGN4WGUkaMpx5hvdTbYYqw01qoY2GrHi+kAR6SVofynzD6KbGoF5ITP0zh5pvg==",
+			"version": "5.1.28",
+			"resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.28.tgz",
+			"integrity": "sha512-nu0VKNybkjvUqJAXWtRqKd7j3iRUl8GbYSTvZNuIBJcw/HUp1Y4QUXNLlj7gcnRV/t784JnHAlvRnSnE3nPbJA==",
 			"dev": true,
 			"dependencies": {
 				"@types/hoist-non-react-statics": "*",
@@ -2352,15 +2352,15 @@
 			"integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "6.7.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.2.tgz",
-			"integrity": "sha512-KA3E4ox0ws+SPyxQf9iSI25R6b4Ne78ORhNHeVKrPQnoYsb9UhieoiRoJgrzgEeKGOXhcY1i8YtOeCHHTDa6Fw==",
+			"version": "6.7.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.3.tgz",
+			"integrity": "sha512-TlutE+iep2o7R8Lf+yoer3zU6/0EAUc8QIBB3GYBc1KGz4c4TRm83xwXUZVPlZ6YCLss4r77jbu6j3sendJoiQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.7.2",
-				"@typescript-eslint/types": "6.7.2",
-				"@typescript-eslint/typescript-estree": "6.7.2",
-				"@typescript-eslint/visitor-keys": "6.7.2",
+				"@typescript-eslint/scope-manager": "6.7.3",
+				"@typescript-eslint/types": "6.7.3",
+				"@typescript-eslint/typescript-estree": "6.7.3",
+				"@typescript-eslint/visitor-keys": "6.7.3",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -2380,13 +2380,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.7.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.2.tgz",
-			"integrity": "sha512-bgi6plgyZjEqapr7u2mhxGR6E8WCzKNUFWNh6fkpVe9+yzRZeYtDTbsIBzKbcxI+r1qVWt6VIoMSNZ4r2A+6Yw==",
+			"version": "6.7.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.3.tgz",
+			"integrity": "sha512-wOlo0QnEou9cHO2TdkJmzF7DFGvAKEnB82PuPNHpT8ZKKaZu6Bm63ugOTn9fXNJtvuDPanBc78lGUGGytJoVzQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.7.2",
-				"@typescript-eslint/visitor-keys": "6.7.2"
+				"@typescript-eslint/types": "6.7.3",
+				"@typescript-eslint/visitor-keys": "6.7.3"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2397,9 +2397,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.7.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.2.tgz",
-			"integrity": "sha512-flJYwMYgnUNDAN9/GAI3l8+wTmvTYdv64fcH8aoJK76Y+1FCZ08RtI5zDerM/FYT5DMkAc+19E4aLmd5KqdFyg==",
+			"version": "6.7.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.3.tgz",
+			"integrity": "sha512-4g+de6roB2NFcfkZb439tigpAMnvEIg3rIjWQ+EM7IBaYt/CdJt6em9BJ4h4UpdgaBWdmx2iWsafHTrqmgIPNw==",
 			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2410,13 +2410,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.7.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.2.tgz",
-			"integrity": "sha512-kiJKVMLkoSciGyFU0TOY0fRxnp9qq1AzVOHNeN1+B9erKFCJ4Z8WdjAkKQPP+b1pWStGFqezMLltxO+308dJTQ==",
+			"version": "6.7.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.3.tgz",
+			"integrity": "sha512-YLQ3tJoS4VxLFYHTw21oe1/vIZPRqAO91z6Uv0Ss2BKm/Ag7/RVQBcXTGcXhgJMdA4U+HrKuY5gWlJlvoaKZ5g==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.7.2",
-				"@typescript-eslint/visitor-keys": "6.7.2",
+				"@typescript-eslint/types": "6.7.3",
+				"@typescript-eslint/visitor-keys": "6.7.3",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -2437,12 +2437,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.7.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.2.tgz",
-			"integrity": "sha512-uVw9VIMFBUTz8rIeaUT3fFe8xIUx8r4ywAdlQv1ifH+6acn/XF8Y6rwJ7XNmkNMDrTW+7+vxFFPIF40nJCVsMQ==",
+			"version": "6.7.3",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.3.tgz",
+			"integrity": "sha512-HEVXkU9IB+nk9o63CeICMHxFWbHWr3E1mpilIQBe9+7L/lH97rleFLVtYsfnWB+JVMaiFnEaxvknvmIzX+CqVg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.7.2",
+				"@typescript-eslint/types": "6.7.3",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -3049,9 +3049,9 @@
 			"integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
 		},
 		"node_modules/browserslist": {
-			"version": "4.21.11",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.11.tgz",
-			"integrity": "sha512-xn1UXOKUz7DjdGlg9RrUr0GGiWzI97UQJnugHtH0OLDfJB7jMgoIkYvRIEO1l9EeEERVqeqLYOcFBW9ldjypbQ==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+			"integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3067,8 +3067,8 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001538",
-				"electron-to-chromium": "^1.4.526",
+				"caniuse-lite": "^1.0.30001541",
+				"electron-to-chromium": "^1.4.535",
 				"node-releases": "^2.0.13",
 				"update-browserslist-db": "^1.0.13"
 			},
@@ -3127,9 +3127,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001538",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001538.tgz",
-			"integrity": "sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==",
+			"version": "1.0.30001541",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001541.tgz",
+			"integrity": "sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3268,9 +3268,9 @@
 			"dev": true
 		},
 		"node_modules/convert-source-map": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"peer": true
 		},
 		"node_modules/cross-spawn": {
@@ -3422,9 +3422,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.527",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.527.tgz",
-			"integrity": "sha512-EafxEiEDzk2aLrdbtVczylHflHdHkNrpGNHIgDyA63sUQLQVS2ayj2hPw3RsVB42qkwURH+T2OxV7kGPUuYszA=="
+			"version": "1.4.537",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.537.tgz",
+			"integrity": "sha512-W1+g9qs9hviII0HAwOdehGYkr+zt7KKdmCcJcjH0mYg6oL8+ioT3Skjmt7BLoAQqXhjf40AXd+HlR4oAWMlXjA=="
 		},
 		"node_modules/elliptic": {
 			"version": "6.5.4",
@@ -4099,9 +4099,9 @@
 			}
 		},
 		"node_modules/ethers": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.1.tgz",
-			"integrity": "sha512-5krze4dRLITX7FpU8J4WscXqADiKmyeNlylmmDLbS95DaZpBhDe2YSwRQwKXWNyXcox7a3gBgm/MkGXV1O1S/Q==",
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+			"integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
 			"funding": [
 				{
 					"type": "individual",
@@ -4131,7 +4131,7 @@
 				"@ethersproject/networks": "5.7.1",
 				"@ethersproject/pbkdf2": "5.7.0",
 				"@ethersproject/properties": "5.7.0",
-				"@ethersproject/providers": "5.7.1",
+				"@ethersproject/providers": "5.7.2",
 				"@ethersproject/random": "5.7.0",
 				"@ethersproject/rlp": "5.7.0",
 				"@ethersproject/sha2": "5.7.0",
@@ -6769,9 +6769,9 @@
 			}
 		},
 		"node_modules/react-draggable": {
-			"version": "4.4.5",
-			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.5.tgz",
-			"integrity": "sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==",
+			"version": "4.4.6",
+			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
+			"integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
 			"dependencies": {
 				"clsx": "^1.1.1",
 				"prop-types": "^15.8.1"

--- a/src/components/functional/AccountFrame.tsx
+++ b/src/components/functional/AccountFrame.tsx
@@ -21,6 +21,7 @@ const AccountFrame = () => {
 				} else {
 					const account = { addr: accounts[0], shard: getShardFromAddress(accounts[0]) }
 					const rpcUrl = getRPCURL(account.shard, 'local')
+					const wsUrl = getRPCURL(account.shard, 'ws-local')
 					const contractAddress = getContractAddressFromShard(account.shard)
 					dispatch({
 						type: 'SET_ACCOUNT',
@@ -29,6 +30,10 @@ const AccountFrame = () => {
 					dispatch({
 						type: 'SET_RPC_URL',
 						payload: rpcUrl,
+					})
+					dispatch({
+						type: 'SET_WS_URL',
+						payload: wsUrl,
 					})
 					dispatch({
 						type: 'SET_CONTRACT_ADDRESS',

--- a/src/components/functional/GameComponents.tsx
+++ b/src/components/functional/GameComponents.tsx
@@ -11,8 +11,6 @@ export const Bet = ({ setIsFlipStatusModalOpen }: FlipStatusModalProps) => {
 	const { play } = useContract()
 
 	const HandleFlip = () => {
-		setIsFlipStatusModalOpen(true)
-		// let choice = isHeads ? 'true' : 'false'
 		play(isHeads, bet, setIsFlipStatusModalOpen)
 	}
 

--- a/src/components/functional/GameComponents.tsx
+++ b/src/components/functional/GameComponents.tsx
@@ -102,6 +102,7 @@ export const FlipStats = () => {
 
 	useEffect(() => {
 		getGameCountAndBalance()
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [])
 	return (
 		<Fieldset legend='Details'>

--- a/src/components/functional/GameTable.tsx
+++ b/src/components/functional/GameTable.tsx
@@ -23,6 +23,7 @@ const GameTable = () => {
 
 	useEffect(() => {
 		getGameCountAndBalance()
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [])
 
 	const forEveryObjectInArrayCreateTableRow = () => {

--- a/src/hooks/usePelagus.ts
+++ b/src/hooks/usePelagus.ts
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import { GlobalDispatchContext } from '../utils/store'
 import { getShardFromAddress } from 'quais/lib/utils'
-import { getContractAddressFromShard, getRPCURL } from '../utils/helpers'
+import { getContractAddressFromShard, getRPCURL, getWSURL } from '../utils/helpers'
 
 const usePelagus = () => {
 	const dispatch = useContext(GlobalDispatchContext)
@@ -19,6 +19,7 @@ const usePelagus = () => {
 				dispatch({ type: 'SET_CONNECTED', payload: true })
 				dispatch({ type: 'SET_CONTRACT_ADDRESS', payload: contractAddress })
 				dispatch({ type: 'SET_RPC_URL', payload: getRPCURL(account.shard, 'local') })
+				dispatch({ type: 'SET_WS_URL', payload: getWSURL(account.shard, 'ws-local') })
 			})
 			.catch((err: Error) => {
 				console.log('Error getting accounts.', err)
@@ -42,6 +43,7 @@ const usePelagus = () => {
 						dispatch({ type: 'SET_CONNECTED', payload: true })
 						dispatch({ type: 'SET_CONTRACT_ADDRESS', payload: contractAddress })
 						dispatch({ type: 'SET_RPC_URL', payload: getRPCURL(account.shard, 'local') })
+						dispatch({ type: 'SET_WS_URL', payload: getWSURL(account.shard, 'ws-local') })
 					}
 				})
 				.catch((err: Error) => {

--- a/src/modals/FlipStatusModal.tsx
+++ b/src/modals/FlipStatusModal.tsx
@@ -18,12 +18,12 @@ const FlipStatusModal = ({ setIsFlipStatusModalOpen }: FlipStatusModalProps) => 
 		winner: '',
 		heads: false,
 	})
-	const { filterOn } = useContract()
+	const { getReceipt } = useContract()
 
 	useEffect(() => {
-		console.log('IN USE EFFECT')
-		const cleanup = filterOn(account.addr, setGameResult)
-		return cleanup
+		console.log('In Use Effect')
+		getReceipt(txHash, setGameResult)
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [])
 
 	var winner = ''

--- a/src/modals/FlipStatusModal.tsx
+++ b/src/modals/FlipStatusModal.tsx
@@ -1,15 +1,30 @@
-import { useContext } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { GlobalStateContext, GlobalDispatchContext } from '../utils/store'
 import { Modal, Frame } from '@react95/core'
 import { Systray304 } from '@react95/icons'
 import { CoinSpin } from '../components/functional/GameComponents'
 import { getExplorerURL } from '../utils/helpers'
+import useContract from '../hooks/useContract'
 
 const FlipStatusModal = ({ setIsFlipStatusModalOpen }: FlipStatusModalProps) => {
 	const state = useContext(GlobalStateContext)
-	const { isFlipping, gameResult, txHash, account } = state
+	const { isFlipping, txHash, account } = state
 	const dispatch = useContext(GlobalDispatchContext)
 	const explorerURL = getExplorerURL(account.shard)
+	const [gameResult, setGameResult] = useState({
+		message: '',
+		player: '',
+		prize: '',
+		winner: '',
+		heads: false,
+	})
+	const { filterOn } = useContract()
+
+	useEffect(() => {
+		console.log('IN USE EFFECT')
+		const cleanup = filterOn(account.addr, setGameResult)
+		return cleanup
+	}, [])
 
 	var winner = ''
 	var choice = ''

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -24,6 +24,17 @@ export const RPCURLs = {
 		'zone-2-1': 'https://rpc.hydra2.colosseum.quaiscan.io',
 		'zone-2-2': 'https://rpc.hydra3.colosseum.quaiscan.io',
 	},
+	'ws-local': {
+		'zone-0-0': 'ws://localhost:8611',
+		'zone-0-1': 'ws://localhost:8643',
+		'zone-0-2': 'ws://localhost:8675',
+		'zone-1-0': 'ws://localhost:8613',
+		'zone-1-1': 'ws://localhost:8645',
+		'zone-1-2': 'ws://localhost:8677',
+		'zone-2-0': 'ws://localhost:8615',
+		'zone-2-1': 'ws://localhost:8647',
+		'zone-2-2': 'ws://localhost:8679',
+	},
 }
 
 // Explorer URLs for transaction links

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -9,6 +9,11 @@ export const getRPCURL = (shardName: string, environment: string) => {
 	return env[shardName as keyof typeof env]
 }
 
+export const getWSURL = (shardName: string, environment: string) => {
+	const env = RPCURLs[environment as keyof typeof RPCURLs]
+	return env[shardName as keyof typeof env].replace('http', 'ws')
+}
+
 export const getContractAddressFromShard = (shardName: string) => {
 	return contractAddresses[shardName as keyof typeof contractAddresses]
 }

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -8,6 +8,7 @@ interface StateData {
 	window: any
 	provider: any
 	rpcUrl: string
+	wsUrl: string
 	signer: any
 	contract: any
 	contractAddress: string
@@ -29,6 +30,7 @@ const typeStateMap = {
 	SET_WINDOW: 'window',
 	SET_PROVIDER: 'provider',
 	SET_RPC_URL: 'rpcUrl',
+	SET_WS_URL: 'wsUrl',
 	SET_SIGNER: 'signer',
 	SET_CONTRACT: 'contract',
 	SET_CONTRACT_ADDRESS: 'contractAddress',
@@ -50,6 +52,7 @@ const initialState = {
 	window: null,
 	provider: null,
 	rpcUrl: '',
+	wsUrl: '',
 	signer: null,
 	contract: null,
 	contractAddress: '',


### PR DESCRIPTION
- Add helper function to return WS url for each shard
- Remove mock modal open for flip flow
- Add contract event listener logic into `useContract.ts`
- Integrate WS logic into wallet connect flow
- Integrate contract event listening into modal flow
- Add WS urls to `contants.ts` and `state.tsx` 

Would largely prefer not use WS for event listeners as RPC endpoints don't have them publicly available. Https event listening appears to be broken with `quais.js`. Opened [an issue](https://github.com/dominant-strategies/quais-5.js/issues/8) in the quais repo, waiting for resolution to move forward with http based event listeners.